### PR TITLE
Fix running benchmarks with geofileops

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,11 +36,11 @@ jobs:
           chmod +x scripts/download_alkis_data.sh
           ./scripts/download_alkis_data.sh
       
-      - name: Install GDAL and Java (Ubuntu default)
+      - name: Install GDAL, Java and spatialite (Ubuntu default)
         run: |
           # Install system packages (now with constrained Python GDAL version)
           sudo apt-get update -qq
-          sudo apt-get install -y gdal-bin libgdal-dev openjdk-11-jdk
+          sudo apt-get install -y gdal-bin libgdal-dev openjdk-11-jdk libsqlite3-mod-spatialite
           echo "System GDAL version: $(gdal-config --version)"
           echo "✅ GDAL $(gdal-config --version) installed - Python GDAL constrained to 3.8.x"
       

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,11 +47,11 @@ jobs:
           chmod +x scripts/download_alkis_data.sh
           ./scripts/download_alkis_data.sh
       
-      - name: Install GDAL and Java (Ubuntu default)
+      - name: Install GDAL, Java and spatialite (Ubuntu default)
         run: |
           # Install system packages (now with constrained Python GDAL version)
           sudo apt-get update -qq
-          sudo apt-get install -y gdal-bin libgdal-dev openjdk-11-jdk
+          sudo apt-get install -y gdal-bin libgdal-dev openjdk-11-jdk libsqlite3-mod-spatialite
           echo "System GDAL version: $(gdal-config --version)"
           echo "✅ GDAL $(gdal-config --version) installed - Python GDAL constrained to 3.8.x"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "duckdb~=1.3.2",
     "pyspark==3.5.6",
     "apache-sedona[spark]==1.7.2",
-    "geofileops>=0.10.1",
+    "geofileops>=0.10.2",
 ]
 
 [dependency-groups]
@@ -32,11 +32,6 @@ dev = [
     "coverage[toml]",
     "ruff",
     "ty>=0.0.1a19",
-]
-geofileops = [
-    "geofileops>=0.10.1; sys_platform != 'win32'",  # Unix/macOS only
-    # Windows: Use conda-forge for GDAL compatibility
-    # conda install -c conda-forge gdal geofileops
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ unfixable = []
     "S603",    # Allow subprocess calls in tests (for integration testing)
 ]
 
+[tool.uv]
+no-binary-package = ["pyogrio"]  # pyogrio with binaries installs an extra GDAL without mod_spatialite
+
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "duckdb~=1.3.2",
     "pyspark==3.5.6",
     "apache-sedona[spark]==1.7.2",
+    "geofileops>=0.10.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ unfixable = []
 ]
 
 [tool.uv]
-no-binary-package = ["pyogrio"]  # pyogrio with binaries installs an extra GDAL without mod_spatialite
+# If pyogrio is installed with binaries, it installs an extra GDAL that does not include
+# mod_spatialite which breaks geofileops.
+no-binary-package = ["pyogrio"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "ty>=0.0.1a19",
 ]
 geofileops = [
-    "geofileops>=0.10.0; sys_platform != 'win32'",  # Unix/macOS only
+    "geofileops>=0.10.1; sys_platform != 'win32'",  # Unix/macOS only
     # Windows: Use conda-forge for GDAL compatibility
     # conda install -c conda-forge gdal geofileops
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "gdal"
-version = "3.9.0"
+version = "3.8.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/45/ab2b3012a796a13844dd21742594e04d85059b6ac9fc223ebfc005a2e116/GDAL-3.9.0.tar.gz", hash = "sha256:7c2a857cf903b9921357e0dfae593f2fe6f7dcd2ea42600577d5fc3c864fb066", size = 839919, upload-time = "2024-05-10T13:53:55.55Z" }
 


### PR DESCRIPTION
Changes:
- Make sure the gdal python bindings being installed are of the same version as the gdal being installed on the system
    - version 3.8.4 instead of 3.9.0
- Add system installation of libsqlite3-mod-spatialite
- Avoid pyogrio installing it's own version of gdal via it's wheels